### PR TITLE
Close file handle after export

### DIFF
--- a/java/BinExport/src/main/java/com/google/security/binexport/BinExportExporter.java
+++ b/java/BinExport/src/main/java/com/google/security/binexport/BinExportExporter.java
@@ -86,9 +86,9 @@ public class BinExportExporter extends Exporter {
 
       monitor.setMessage("Writing BinExport2 file");
 
-      var outputStream = new FileOutputStream(file);
-      proto.writeTo(outputStream);
-      outputStream.close();
+      try (final var outputStream = new FileOutputStream(file)) {
+        proto.writeTo(outputStream);
+      }
     } catch (final CancelledException e) {
       return false;
     }

--- a/java/BinExport/src/main/java/com/google/security/binexport/BinExportExporter.java
+++ b/java/BinExport/src/main/java/com/google/security/binexport/BinExportExporter.java
@@ -85,7 +85,10 @@ public class BinExportExporter extends Exporter {
       final BinExport2 proto = builder.build(monitor);
 
       monitor.setMessage("Writing BinExport2 file");
-      proto.writeTo(new FileOutputStream(file));
+
+      var outputStream = new FileOutputStream(file);
+      proto.writeTo(outputStream);
+      outputStream.close();
     } catch (final CancelledException e) {
       return false;
     }


### PR DESCRIPTION
(On Windows) the file handle is kept open after exporting a file. This means you can't move, edit or delete the file until Ghidra is closed.

It's probably on other OSs too, since the Exporter Instance is kept for the Lifetime of the Ghidra App, the FileOutputStream never gets collected and closed.

Explicitly calling FileOutputStream.close() solves the problem