### PR TITLE
Added option for prepending "namespace::" to functions

### DIFF
--- a/java/BinExport/src/main/java/com/google/security/binexport/BinExport2Builder.java
+++ b/java/BinExport/src/main/java/com/google/security/binexport/BinExport2Builder.java
@@ -36,6 +36,7 @@ import ghidra.program.model.mem.MemoryAccessException;
 import ghidra.program.model.mem.MemoryBlock;
 import ghidra.program.model.scalar.Scalar;
 import ghidra.program.model.symbol.FlowType;
+import ghidra.program.model.symbol.Namespace;
 import ghidra.program.model.symbol.RefType;
 import ghidra.program.model.symbol.Reference;
 import ghidra.program.model.symbol.Symbol;
@@ -344,6 +345,7 @@ public class BinExport2Builder {
     for (final Function func : funcManager.getFunctions(true)) {
       final long funcAddress = getMappedAddress(func.getEntryPoint());
       final var vertex = callGraph.addVertexBuilder().setAddress(funcAddress);
+      final Namespace parentNamespace = func.getParentNamespace();
       // TODO(cblichmann): Imported/library
       if (func.isExternal()) {
         vertex.setType(BinExport2.CallGraph.Vertex.Type.IMPORTED);
@@ -353,9 +355,9 @@ public class BinExport2Builder {
       }
       // TODO(cblichmann): Check for artificial names
       // Mangled name always needs to be set.
-      if (func.getParentNamespace() != null && !func.getParentNamespace().getName().equals("Global") 
+      if (parentNamespace != null && !"Global".equals(parentNamespace.getName()) 
           && this.prependNamespace) {
-        vertex.setMangledName(func.getParentNamespace().getName() + "::" + func.getName());
+        vertex.setMangledName(parentNamespace.getName() + "::" + func.getName());
       } else {
         vertex.setMangledName(func.getName());
       }

--- a/java/BinExport/src/main/java/com/google/security/binexport/BinExport2Builder.java
+++ b/java/BinExport/src/main/java/com/google/security/binexport/BinExport2Builder.java
@@ -68,6 +68,7 @@ public class BinExport2Builder {
 
   private MnemonicMapper mnemonicMapper = new IdentityMnemonicMapper();
   private long addressOffset = 0;
+  private boolean prependNamespace = false;
 
   public BinExport2Builder(Program ghidraProgram) {
     program = ghidraProgram;
@@ -84,6 +85,11 @@ public class BinExport2Builder {
     return this;
   }
 
+  public BinExport2Builder setPrependNamespace(boolean isPrepended) {
+    prependNamespace = isPrepended;
+    return this;
+  }
+  
   private long getMappedAddress(Address address) {
     return address.getOffset() - addressOffset;
   }
@@ -347,7 +353,12 @@ public class BinExport2Builder {
       }
       // TODO(cblichmann): Check for artificial names
       // Mangled name always needs to be set.
-      vertex.setMangledName(func.getName());
+      if (func.getParentNamespace() != null && !func.getParentNamespace().getName().equals("Global") 
+          && this.prependNamespace) {
+        vertex.setMangledName(func.getParentNamespace().getName() + "::" + func.getName());
+      } else {
+        vertex.setMangledName(func.getName());
+      }
       vertexIndices.put(funcAddress, id++);
       monitor.setProgress(i++);
     }

--- a/java/BinExport/src/main/java/com/google/security/binexport/BinExportExporter.java
+++ b/java/BinExport/src/main/java/com/google/security/binexport/BinExportExporter.java
@@ -49,6 +49,8 @@ public class BinExportExporter extends Exporter {
       "Subtract Imagebase";
   private static final String IDAPRO_COMPAT_OPT_REMAP_MNEMONICS =
       "Remap mnemonics";
+  private static final String IDAPRO_COMPAT_OPT_PREPEND_NAMESPACE = 
+      "Prepend Namespace to Function Names";
 
   /** Whether to subtract the program image base from addresses for export. */
   private boolean subtractImagebase = false;
@@ -56,6 +58,9 @@ public class BinExportExporter extends Exporter {
   /** Whether to remap Ghidra's mnenomics into IDA Pro style ones. */
   private boolean remapMnemonics = false;
 
+  /** Whether to prepend "namespace::" to function names where the namespace is not "Global" */
+  private boolean prependNamespace = false;
+  
   public BinExportExporter() {
     super(BINEXPORT_FORMAT_DISPLAY_NAME, BINEXPORT_FILE_EXTENSION, null);
     log.appendMsg("BinExport 11 (c)2019-2020 Google LLC");
@@ -82,6 +87,9 @@ public class BinExportExporter extends Exporter {
       if (subtractImagebase) {
         builder.setAddressOffset(program.getImageBase().getOffset());
       }
+      if (prependNamespace) {
+        builder.setPrependNamespace(true);
+      }
       final BinExport2 proto = builder.build(monitor);
 
       monitor.setMessage("Writing BinExport2 file");
@@ -101,6 +109,8 @@ public class BinExportExporter extends Exporter {
         new Option(IDAPRO_COMPAT_OPTGROUP, IDAPRO_COMPAT_OPT_SUBTRACT_IMAGEBASE,
             Boolean.FALSE),
         new Option(IDAPRO_COMPAT_OPTGROUP, IDAPRO_COMPAT_OPT_REMAP_MNEMONICS,
+            Boolean.FALSE),
+        new Option(IDAPRO_COMPAT_OPTGROUP, IDAPRO_COMPAT_OPT_PREPEND_NAMESPACE, 
             Boolean.FALSE));
   }
 
@@ -113,6 +123,9 @@ public class BinExportExporter extends Exporter {
           break;
         case IDAPRO_COMPAT_OPT_REMAP_MNEMONICS:
           remapMnemonics = (boolean) option.getValue();
+          break;
+        case IDAPRO_COMPAT_OPT_PREPEND_NAMESPACE:
+          prependNamespace = (boolean) option.getValue();
           break;
       }
     }


### PR DESCRIPTION
This more closely mirrors the output provided by IDA since it does not
treat namespaces as a separate part of the function name, at least in
the context of binexport.

Functions belonging to different classes that all implement the same
interface can now be properly identified in BinDiff and name matching is
more useful.