### PR TITLE
Deprecate PostgreSQL database export.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ cmake_minimum_required(VERSION 3.12)
 cmake_policy(VERSION 3.12)
 project(binexport VERSION 11)  # Only major version is used
 
+option(BINEXPORT_ENABLE_POSTGRESQL "Enable export to PostresSQL databases" OFF)
+
 include(GoogleTest) # Needs to come before changing module path
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 include(copts.cmake)
@@ -33,14 +35,16 @@ find_package(Boost 1.55 REQUIRED)
 find_package(Git)
 find_package(IdaSdk REQUIRED)
 find_package(OpenSSL 1.0.2 REQUIRED)
-find_package(PostgreSQL 9.5 REQUIRED)
+if(BINEXPORT_ENABLE_POSTGRESQL)
+  find_package(PostgreSQL 9.5 REQUIRED)
+endif()
 find_package(Protobuf 3.0.0 REQUIRED)
 include(googletest.cmake)
 include(absl.cmake)
 
 enable_testing()
 
-if(WIN32)
+if(BINEXPORT_ENABLE_POSTGRESQL AND WIN32)
   list(GET PostgreSQL_LIBRARIES 0 postgresql_lib)
   get_filename_component(postgresql_root ${postgresql_lib} DIRECTORY)
   list(APPEND PostgreSQL_LIBRARIES ${postgresql_root}/libpgport.lib)
@@ -78,9 +82,16 @@ target_include_directories(binexport_base INTERFACE
   ${PROJECT_BINARY_DIR}/gen_include
   ${PROJECT_BINARY_DIR}/src_include
   ${Boost_INCLUDE_DIR}
-  ${PostgreSQL_INCLUDE_DIRS}
   ${Protobuf_INCLUDE_DIRS}
 )
+if(BINEXPORT_ENABLE_POSTGRESQL)
+  target_include_directories(binexport_base INTERFACE
+    ${PostgreSQL_INCLUDE_DIRS}
+  )
+  target_compile_definitions(binexport_base INTERFACE
+    ENABLE_POSTGRESQL
+  )
+endif()
 target_link_libraries(binexport_base INTERFACE
   ${Protobuf_LIBRARIES}  # Same as protobuf::libprotobuf
 )
@@ -262,18 +273,26 @@ ida_target_link_libraries(binexport_plugin_shared PUBLIC
   binexport_base
 )
 
+set(binexport_POSTGRESQL_SRCS)
+if(BINEXPORT_ENABLE_POSTGRESQL)
+  set(binexport_plugin_POSTGRESQL_SRCS
+    database/initialize_constraints_postgresql_sql.h
+    database/initialize_indices_postgresql_sql.h
+    database/initialize_tables_postgresql_sql.h
+    database/maintenance_postgresql_sql.h
+    database/postgresql.cc
+    database/postgresql.h
+    database/postgresql_writer.cc
+    database/postgresql_writer.h
+    database/query_builder.cc
+    database/query_builder.h
+    ida/types_container.cc
+    ida/types_container.h
+  )
+endif()
 set(binexport_plugin_name binexport${binexport_VERSION_MAJOR})
 add_ida_plugin(${binexport_plugin_name}
-  database/initialize_constraints_postgresql_sql.h
-  database/initialize_indices_postgresql_sql.h
-  database/initialize_tables_postgresql_sql.h
-  database/maintenance_postgresql_sql.h
-  database/postgresql.cc
-  database/postgresql.h
-  database/postgresql_writer.cc
-  database/postgresql_writer.h
-  database/query_builder.cc
-  database/query_builder.h
+  ${binexport_plugin_POSTGRESQL_SRCS}
   ida/arm.cc
   ida/arm.h
   ida/dalvik.cc
@@ -291,11 +310,16 @@ add_ida_plugin(${binexport_plugin_name}
   ida/plugin.h
   ida/ppc.cc
   ida/ppc.h
-  ida/types_container.cc
-  ida/types_container.h
   ida/ui.cc
   ida/ui.h
 )
+if(BINEXPORT_ENABLE_POSTGRESQL)
+  list(APPEND binexport_libraries
+    ${PostgreSQL_LIBRARIES}
+    # OpenSSL must come after PostgreSQL
+    OpenSSL::SSL
+  )
+endif()
 if(WIN32)
   list(APPEND binexport_libraries crypt32.lib
                                   secur32.lib
@@ -315,9 +339,6 @@ ida_target_link_libraries(${binexport_plugin_name}
   absl::time
   binexport_core
   binexport_plugin_shared
-  ${PostgreSQL_LIBRARIES}
-  # OpenSSL must come after PostgreSQL
-  OpenSSL::SSL
   ${binexport_libraries}
 )
 set_ida_target_properties(${binexport_plugin_name}

--- a/binexport2_writer.cc
+++ b/binexport2_writer.cc
@@ -750,7 +750,7 @@ BinExport2Writer::BinExport2Writer(const std::string& result_filename,
 absl::Status BinExport2Writer::WriteToProto(
     const CallGraph& call_graph, const FlowGraph& flow_graph,
     const Instructions& instructions,
-    const AddressReferences& address_references, const TypeSystem* type_system,
+    const AddressReferences& address_references,
     const AddressSpace& address_space, BinExport2* proto) const {
   auto* meta_information = proto->mutable_meta_information();
   meta_information->set_executable_name(executable_filename_);
@@ -783,14 +783,13 @@ absl::Status BinExport2Writer::WriteToProto(
 absl::Status BinExport2Writer::Write(
     const CallGraph& call_graph, const FlowGraph& flow_graph,
     const Instructions& instructions,
-    const AddressReferences& address_references, const TypeSystem* type_system,
+    const AddressReferences& address_references, const TypeSystem*,
     const AddressSpace& address_space) {
   LOG(INFO) << "Writing to: \"" << filename_ << "\".";
 
   BinExport2 proto;
   NA_RETURN_IF_ERROR(WriteToProto(call_graph, flow_graph, instructions,
-                                  address_references, type_system,
-                                  address_space, &proto));
+                                  address_references, address_space, &proto));
   return WriteProtoToFile(filename_, &proto);
 }
 

--- a/binexport2_writer.h
+++ b/binexport2_writer.h
@@ -33,14 +33,13 @@ class BinExport2Writer : public Writer {
   absl::Status Write(const CallGraph& call_graph, const FlowGraph& flow_graph,
                      const Instructions& instructions,
                      const AddressReferences& address_references,
-                     const TypeSystem* type_system,
+                     const TypeSystem*,
                      const AddressSpace& address_space) override;
 
   absl::Status WriteToProto(const CallGraph& call_graph,
                             const FlowGraph& flow_graph,
                             const Instructions& instructions,
                             const AddressReferences& address_references,
-                            const TypeSystem* type_system,
                             const AddressSpace& address_space,
                             BinExport2* proto) const;
 

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -10,7 +10,10 @@ Configure with locally installed IDA SDK at `/opt/idasdk`:
    cd build
    cmake ../cmake -DIdaSdk_ROOT_DIR=/opt/idasdk -DCMAKE_BUILD_TYPE=Release
 
-Replace `Release` with `Debug` for a debug build.
+Replace `Release` with `Debug` for a debug build. To enable support for
+exporting into PostgreSQL databases, add `-DBINEXPORT_ENABLE_POSTGRESQL=ON` to
+the command.
+
 
 To download, configure and install all other external dependencies and start
 the build:
@@ -32,7 +35,9 @@ the build:
 
    cmake --build . --config Release
 
-Replace `Release` with `Debug` for a debug build.
+Replace `Release` with `Debug` for a debug build. To enable support for
+exporting into PostgreSQL databases, add `-DBINEXPORT_ENABLE_POSTGRESQL=ON` to
+the command.
 
 
 Windows
@@ -49,4 +54,6 @@ the build:
 
    cmake --build . --config Release -- /clp:NoSummary;ForceNoAlign /v:minimal
 
-Replace `Release` with `Debug` for a debug build.
+Replace `Release` with `Debug` for a debug build. To enable support for
+exporting into PostgreSQL databases, add `-DBINEXPORT_ENABLE_POSTGRESQL=ON` to
+the command.

--- a/dump_writer.cc
+++ b/dump_writer.cc
@@ -28,12 +28,9 @@ DumpWriter::DumpWriter(const std::string& file_name)
     : file_(file_name.c_str()), stream_(file_) {}
 
 absl::Status DumpWriter::Write(const CallGraph& call_graph,
-                               const FlowGraph& flow_graph,
-                               const Instructions& instructions,
-                               const AddressReferences& address_references,
-                               const TypeSystem* type_system,
-                               const AddressSpace& address_space) {
-
+                               const FlowGraph& flow_graph, const Instructions&,
+                               const AddressReferences&, const TypeSystem*,
+                               const AddressSpace&) {
   stream_ << std::endl;
   call_graph.Render(&stream_, flow_graph);
   stream_ << std::endl;

--- a/dump_writer.h
+++ b/dump_writer.h
@@ -27,10 +27,8 @@ class DumpWriter : public Writer {
   explicit DumpWriter(const std::string& file_name);
 
   absl::Status Write(const CallGraph& call_graph, const FlowGraph& flow_graph,
-                     const Instructions& instructions,
-                     const AddressReferences& address_references,
-                     const TypeSystem* type_system,
-                     const AddressSpace& address_space) override;
+                     const Instructions&, const AddressReferences&,
+                     const TypeSystem*, const AddressSpace&) override;
 
  private:
   std::ofstream file_;

--- a/ida/arm.cc
+++ b/ida/arm.cc
@@ -480,8 +480,7 @@ Operands DecodeOperandsArm(const insn_t& instruction) {
 
 Instruction ParseInstructionIdaArm(const insn_t& instruction,
                                    CallGraph* /* call_graph */,
-                                   FlowGraph* /* flow_graph */,
-                                   TypeSystem* /* type_system */) {
+                                   FlowGraph* /* flow_graph */, TypeSystem*) {
   if (!IsCode(instruction.ea)) {
     return Instruction(instruction.ea);
   }

--- a/ida/arm.h
+++ b/ida/arm.h
@@ -27,7 +27,7 @@ namespace security::binexport {
 
 Instruction ParseInstructionIdaArm(const insn_t& instruction,
                                    CallGraph* call_graph, FlowGraph* flow_graph,
-                                   TypeSystem* type_system);
+                                   TypeSystem*);
 
 }  // namespace security::binexport
 

--- a/ida/dalvik.cc
+++ b/ida/dalvik.cc
@@ -326,8 +326,7 @@ Operands ParseOperandsIdaDalvik(const insn_t& instruction,
 
 Instruction ParseInstructionIdaDalvik(const insn_t& instruction,
                                       CallGraph* call_graph,
-                                      FlowGraph* flow_graph,
-                                      TypeSystem* /* type_system */) {
+                                      FlowGraph* flow_graph, TypeSystem*) {
   // If the address contains no code of if the text representation could not
   // be generated, return an empty instruction. Do the same if the mnemonic
   // is empty.

--- a/ida/dalvik.h
+++ b/ida/dalvik.h
@@ -28,7 +28,7 @@ namespace security::binexport {
 Instruction ParseInstructionIdaDalvik(const insn_t& instruction,
                                       CallGraph* call_graph,
                                       FlowGraph* flow_graph,
-                                      TypeSystem* type_system);
+                                      TypeSystem*);
 
 }  // namespace security::binexport
 

--- a/ida/generic.cc
+++ b/ida/generic.cc
@@ -33,7 +33,7 @@ namespace security::binexport {
 Instruction ParseInstructionIdaGeneric(const insn_t& instruction,
                                        CallGraph* /* call_graph */,
                                        FlowGraph* /* flow_graph */,
-                                       TypeSystem* /* type_system */) {
+                                       TypeSystem*) {
   if (!IsCode(instruction.ea)) {
     return Instruction(instruction.ea);
   }

--- a/ida/generic.h
+++ b/ida/generic.h
@@ -28,7 +28,7 @@ namespace security::binexport {
 Instruction ParseInstructionIdaGeneric(const insn_t& instruction,
                                        CallGraph* call_graph,
                                        FlowGraph* flow_graph,
-                                       TypeSystem* type_system);
+                                       TypeSystem*);
 
 }  // namespace security::binexport
 

--- a/ida/metapc.cc
+++ b/ida/metapc.cc
@@ -208,7 +208,12 @@ void HandlePhraseExpression(Expressions* expressions, FlowGraph* flow_graph,
     }
   }
 
-  type_system->AddTypeSubstitution(instruction.ea, operand_num, temp->GetId());
+#ifdef ENABLE_POSTGRESQL
+  if (type_system) {
+    type_system->AddTypeSubstitution(instruction.ea, operand_num,
+                                     temp->GetId());
+  }
+#endif
 }
 
 // Creates a tree for expressions of the form:

--- a/ida/mips.cc
+++ b/ida/mips.cc
@@ -285,7 +285,7 @@ Operands DecodeOperandsMips(const insn_t& instruction) {
 Instruction ParseInstructionIdaMips(const insn_t& instruction,
                                     CallGraph* /* call_graph */,
                                     FlowGraph* /* flow_graph */,
-                                    TypeSystem* /* type_system */) {
+                                    TypeSystem*) {
   if (!IsCode(instruction.ea)) {
     return Instruction(instruction.ea);
   }

--- a/ida/mips.h
+++ b/ida/mips.h
@@ -28,7 +28,7 @@ namespace security::binexport {
 Instruction ParseInstructionIdaMips(const insn_t& instruction,
                                     CallGraph* call_graph,
                                     FlowGraph* flow_graph,
-                                    TypeSystem* type_system);
+                                    TypeSystem*);
 
 }  // namespace security::binexport
 

--- a/ida/names.cc
+++ b/ida/names.cc
@@ -705,9 +705,11 @@ void AnalyzeFlowIda(EntryPoints* entry_points, const ModuleMap* modules,
         GetPermissions(segment));
   }
 
-  LOG(INFO) << "gathering types";
   IdaTypesContainer types;
+#ifdef ENABLE_POSTGRESQL
+  LOG(INFO) << "gathering types";
   types.GatherTypes();
+#endif
   TypeSystem type_system(types, address_space);
 
   Instruction::SetBitness(GetArchitectureBitness());

--- a/ida/ppc.cc
+++ b/ida/ppc.cc
@@ -593,8 +593,7 @@ Operands DecodeOperandsPpc(const insn_t& instruction) {
 
 Instruction ParseInstructionIdaPpc(const insn_t& instruction,
                                    CallGraph* /* call_graph */,
-                                   FlowGraph* /* flow_graph */,
-                                   TypeSystem* /* type_system */) {
+                                   FlowGraph* /* flow_graph */, TypeSystem*) {
   if (!IsCode(instruction.ea)) {
     return Instruction(instruction.ea);
   }

--- a/ida/ppc.h
+++ b/ida/ppc.h
@@ -27,7 +27,7 @@ namespace security::binexport {
 
 Instruction ParseInstructionIdaPpc(const insn_t& instruction,
                                    CallGraph* call_graph, FlowGraph* flow_graph,
-                                   TypeSystem* type_system);
+                                   TypeSystem*);
 
 }  // namespace security::binexport
 

--- a/statistics_writer.cc
+++ b/statistics_writer.cc
@@ -93,10 +93,9 @@ void StatisticsWriter::GenerateStatistics(
 
 absl::Status StatisticsWriter::Write(const CallGraph& call_graph,
                                      const FlowGraph& flow_graph,
-                                     const Instructions& /* instructions */,
+                                     const Instructions&,
                                      const AddressReferences&,
-                                     const TypeSystem* /* type_system */,
-                                     const AddressSpace& /* address_space */) {
+                                     const TypeSystem*, const AddressSpace&) {
   std::map<std::string, size_t> statistics;
   GenerateStatistics(call_graph, flow_graph, &statistics);
   for (const auto& entry : statistics) {

--- a/statistics_writer.h
+++ b/statistics_writer.h
@@ -31,10 +31,8 @@ class StatisticsWriter : public Writer {
                           std::map<std::string, size_t>* statistics) const;
 
   absl::Status Write(const CallGraph& call_graph, const FlowGraph& flow_graph,
-                     const Instructions& instructions,
-                     const AddressReferences& address_references,
-                     const TypeSystem* type_system,
-                     const AddressSpace& address_space) override;
+                     const Instructions&, const AddressReferences&,
+                     const TypeSystem*, const AddressSpace&) override;
 
  private:
   std::ofstream file_;


### PR DESCRIPTION
This was used by BinNavi, which is no longer under active development.
The code is still shipped, but the functionality is now disabled by
default.

To build with PostgreSQL support, configure with the
`-DBINEXPORT_ENABLE_POSTGRESQL=ON` argument on the CMake command line.

Signed-off-by: Christian Blichmann <mail@blichmann.eu>