### PR TITLE
Add address validation to Binary Ninja exporter

### DIFF
--- a/binaryninja/main_plugin.cc
+++ b/binaryninja/main_plugin.cc
@@ -332,7 +332,7 @@ void AnalyzeFlowBinaryNinja(BinaryNinja::BinaryView* view,
     const Address address = entry_points->back().address_;
     entry_points->pop_back();
 
-    if (flags[address] & FLAG_VISITED) {
+    if (!flags.IsValidAddress(address) || (flags[address] & FLAG_VISITED)) {
       continue;
     }
     flags[address] |= FLAG_VISITED;


### PR DESCRIPTION
This fixes a crash caused by flow to outside of the BinaryView, which would result in addresses not present in `flags` to be accessed.

The IDA exporter already does this, as such I'm not sure if the omission of this check was intentional as the Binary Ninja exporter seems to be derived from the IDA version; in any case it has produced crashes on binaries I've worked with.