### PR TITLE
Use ordered Abseil containers where order matters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ add_library(binexport_core
 )
 target_link_libraries(binexport_core PUBLIC
   absl::bad_optional_access
+  absl::btree
   absl::flat_hash_map
   absl::flat_hash_set
   absl::hash

--- a/address_references.h
+++ b/address_references.h
@@ -68,7 +68,7 @@ struct AddressReference {
   uint8_t kind_;
 };
 
-typedef std::vector<AddressReference> AddressReferences;
+using AddressReferences = std::vector<AddressReference>;
 
 bool operator<(const AddressReference& one, const AddressReference& two);
 bool operator==(const AddressReference& one, const AddressReference& two);

--- a/basic_block.cc
+++ b/basic_block.cc
@@ -32,24 +32,23 @@ void BasicBlockInstructions::AddInstruction(
 }
 
 BasicBlock* BasicBlock::Create(BasicBlockInstructions* instructions) {
-  typedef NestedIterator<
-      typename BasicBlockInstructions::InstructionRanges::const_iterator>
-      Iterator;
+  using Iterator = NestedIterator<
+      typename BasicBlockInstructions::InstructionRanges::const_iterator>;
 
-  auto ranges_end(instructions->ranges_.end());
+  auto ranges_end = instructions->ranges_.end();
   Iterator instruction_first(instructions->ranges_.begin(), ranges_end);
   if (instruction_first == Iterator(ranges_end)) {
     return nullptr;
   }
 
   // Create the BasicBlock later if one does not exist here already.
-  auto emplace_result(cache_.emplace(instruction_first->GetAddress(),
-                                     nullptr /* no BasicBlock */));
-  if (!emplace_result.second) {
+  auto [entry, found] = cache_.emplace(instruction_first->GetAddress(),
+                                       nullptr /* no BasicBlock */);
+  if (!found) {
     return nullptr;
   }
 
-  auto& ptr(emplace_result.first->second);
+  auto& ptr = entry->second;
   ptr.reset(new BasicBlock(instructions));
   instructions->Clear();
   return ptr.get();
@@ -99,7 +98,7 @@ BasicBlock::InstructionConstIterator BasicBlock::GetInstruction(
 }
 
 BasicBlock::RangeConstIterator BasicBlock::BeforeEndRange() const {
-  auto last(ranges_.before_begin());
+  auto last = ranges_.before_begin();
   // This is O(n) on ranges, however there should be only one range usually.
   for (auto range(ranges_.begin()), ranges_end(ranges_.end());
        range != ranges_end; ++range) {

--- a/basic_block.h
+++ b/basic_block.h
@@ -22,6 +22,7 @@
 #include <vector>
 #undef max
 
+#include "absl/container/btree_map.h"
 #include "third_party/zynamics/binexport/instruction.h"
 #include "third_party/zynamics/binexport/nested_iterator.h"
 #include "third_party/zynamics/binexport/range.h"
@@ -55,7 +56,7 @@ using BasicBlocks = std::vector<BasicBlock*>;
 class BasicBlock {
  private:
   // Important: This must be a sorted container.
-  using Cache = std::map<Address, std::unique_ptr<BasicBlock>>;
+  using Cache = absl::btree_map<Address, std::unique_ptr<BasicBlock>>;
 
   // In most cases there is only one InstructionRange per BasicBlock. Exceptions
   // are overlapping instructions and appended BasicBlocks. A linked list is

--- a/basic_block.h
+++ b/basic_block.h
@@ -45,28 +45,32 @@ class BasicBlockInstructions {
   void Clear() { ranges_.clear(); }
 
  private:
-  typedef std::vector<InstructionRange> InstructionRanges;
+  using InstructionRanges = std::vector<InstructionRange>;
   InstructionRanges ranges_;
 };
 
-typedef std::vector<BasicBlock*> BasicBlocks;
+using BasicBlocks = std::vector<BasicBlock*>;
 
 #pragma pack(push, 1)
 class BasicBlock {
  private:
   // Important: This must be a sorted container.
-  typedef std::map<Address, std::unique_ptr<BasicBlock>> Cache;
+  using Cache = std::map<Address, std::unique_ptr<BasicBlock>>;
 
   // In most cases there is only one InstructionRange per BasicBlock. Exceptions
   // are overlapping instructions and appended BasicBlocks. A linked list is
   // used because it has the lowest memory overhead with only one element.
-  typedef std::forward_list<InstructionRange> InstructionRanges;
-  typedef InstructionRanges::iterator RangeIterator;
-  typedef InstructionRanges::const_iterator RangeConstIterator;
+  using InstructionRanges = std::forward_list<InstructionRange>;
+  using RangeIterator = InstructionRanges::iterator;
+  using RangeConstIterator = InstructionRanges::const_iterator;
 
  public:
-  typedef NestedIterator<RangeIterator> InstructionIterator;
-  typedef NestedIterator<RangeConstIterator> InstructionConstIterator;
+  using InstructionIterator = NestedIterator<RangeIterator>;
+  using InstructionConstIterator = NestedIterator<RangeConstIterator>;
+
+  // Copying disallowed to avoid deep-copies of ranges_ container.
+  BasicBlock(const BasicBlock&) = delete;
+  const BasicBlock& operator=(const BasicBlock&) = delete;
 
   // Returns the basic block at entry_point_address.
   static BasicBlock* Find(Address entry_point_address) {
@@ -159,10 +163,6 @@ class BasicBlock {
               const FlowGraph& flow_graph) const;
 
  private:
-  // Copying disallowed to avoid deep-copies of ranges_ container.
-  BasicBlock(const BasicBlock&) = delete;
-  const BasicBlock& operator=(const BasicBlock&) = delete;
-
   explicit BasicBlock(BasicBlockInstructions* instructions) : id_(-1) {
     Append(&instructions->ranges_);
   }
@@ -180,10 +180,10 @@ class BasicBlock {
 
   RangeConstIterator BeforeEndRange() const;
 
+  static Cache cache_;
+
   int id_;  // Careful: This might not stay constant for shared basic blocks.
   InstructionRanges ranges_;
-
-  static Cache cache_;
 };
 #pragma pack(pop)
 

--- a/call_graph.h
+++ b/call_graph.h
@@ -18,6 +18,7 @@
 #include <iosfwd>
 #include <set>
 
+#include "third_party/absl/container/btree_set.h"
 #include "third_party/absl/container/node_hash_map.h"
 #include "third_party/absl/container/node_hash_set.h"
 #include "third_party/zynamics/binexport/comment.h"
@@ -40,7 +41,7 @@ struct EdgeInfo {
 class CallGraph {
  public:
   // This set should be sorted.
-  using FunctionEntryPoints = std::set<Address>;
+  using FunctionEntryPoints = absl::btree_set<Address>;
 
   using Edges = std::vector<EdgeInfo>;
   using StringReferences = absl::node_hash_map<Address, size_t>;

--- a/entry_point.h
+++ b/entry_point.h
@@ -73,7 +73,7 @@ class EntryPoint {
 bool operator<(const EntryPoint& lhs, const EntryPoint& rhs);
 bool operator==(const EntryPoint& lhs, const EntryPoint& rhs);
 
-typedef std::vector<EntryPoint> EntryPoints;
+using EntryPoints = std::vector<EntryPoint>;
 
 class EntryPointManager {
  public:

--- a/expression.h
+++ b/expression.h
@@ -167,7 +167,7 @@ class Expression {
 };
 #pragma pack(pop)
 
-typedef std::vector<Expression*> Expressions;
+using Expressions = std::vector<Expression*>;
 std::ostream& operator<<(std::ostream& stream, const Expression& expression);
 
 class Instruction;

--- a/flow_graph.h
+++ b/flow_graph.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <tuple>
 
+#include "absl/container/btree_map.h"
 #include "third_party/absl/container/node_hash_set.h"
 #include "third_party/zynamics/binexport/edge.h"
 #include "third_party/zynamics/binexport/function.h"
@@ -43,7 +44,7 @@ class FlowGraph {
 
   // Instruction address, operand number, expression id
   using Ref = std::tuple<Address, uint8_t, int>;
-  using Substitutions = std::map<Ref, const std::string*>;  // Ordered
+  using Substitutions = absl::btree_map<Ref, const std::string*>;  // Ordered
   using Edges = std::vector<FlowGraphEdge>;
 
   FlowGraph() = default;

--- a/function.h
+++ b/function.h
@@ -16,8 +16,8 @@
 #define FUNCTION_H_
 
 #include <cstdint>
-#include <map>
 
+#include "absl/container/btree_map.h"
 #include "third_party/absl/container/node_hash_set.h"
 #include "third_party/zynamics/binexport/basic_block.h"
 #include "third_party/zynamics/binexport/edge.h"
@@ -27,7 +27,7 @@ class CallGraph;
 class Function;
 class FlowGraph;
 
-using Functions = std::map<Address, Function*>;
+using Functions = absl::btree_map<Address, Function*>;
 
 class Function {
  public:

--- a/ida/flow_analysis.h
+++ b/ida/flow_analysis.h
@@ -17,6 +17,7 @@
 
 #include <map>
 
+#include "absl/container/btree_map.h"
 #include "third_party/zynamics/binexport/call_graph.h"
 #include "third_party/zynamics/binexport/entry_point.h"
 #include "third_party/zynamics/binexport/expression.h"
@@ -27,8 +28,8 @@
 
 namespace security::binexport {
 
-// TODO(cblichmann): Use absl::btree_map and CacheString
-using ModuleMap = std::map<Address, std::string>;
+// TODO(cblichmann): Use CacheString
+using ModuleMap = absl::btree_map<Address, std::string>;
 
 // Creates a map "function address" -> "module name"
 ModuleMap InitModuleMap();

--- a/ida/metapc.cc
+++ b/ida/metapc.cc
@@ -14,6 +14,7 @@
 
 #include "third_party/zynamics/binexport/ida/metapc.h"
 
+#include <array>
 #include <cinttypes>
 #include <limits>
 #include <string>
@@ -37,10 +38,13 @@
 namespace security::binexport {
 namespace {
 
-bool IsStringInstruction(const std::string& mnemonic) {
-  static auto* instructions = new std::set<std::string>{
-      "ins", "outs", "movs", "cmps", "stos", "lods", "scas"};
-  return instructions->find(mnemonic.substr(0, 4)) != instructions->end();
+bool IsStringInstruction(absl::string_view mnemonic) {
+  constexpr std::array<absl::string_view, 7> kStringInstructions = {
+      // Keep sorted
+      "cmps", "ins", "lods", "movs", "outs", "scas", "stos",
+  };
+  return std::binary_search(kStringInstructions.begin(),
+                            kStringInstructions.end(), mnemonic.substr(0, 4));
 }
 
 std::string GetSegmentSelector(const op_t& operand) {

--- a/ida/names.cc
+++ b/ida/names.cc
@@ -37,6 +37,7 @@
 // clang-format on
 
 #include "base/logging.h"
+#include "absl/container/btree_map.h"
 #include "third_party/absl/strings/ascii.h"
 #include "third_party/absl/strings/str_cat.h"
 #include "third_party/absl/time/time.h"
@@ -548,8 +549,7 @@ void GetGlobalReferences(Address address, Comments* comments) {
   }
 }
 
-class FunctionCache {
- public:
+struct FunctionCache {
   explicit FunctionCache(func_t* function) : function(function) {
     if (!function) {
       return;
@@ -587,7 +587,7 @@ class FunctionCache {
   }
 
   func_t* function;
-  std::map<ea_t, std::string> local_vars;
+  absl::btree_map<ea_t, std::string> local_vars;
 };
 
 void GetLocalReferences(const insn_t& instruction, Comments* comments) {

--- a/ida/types_container.h
+++ b/ida/types_container.h
@@ -58,8 +58,8 @@ class IdaTypesContainer : public TypesContainer {
   virtual const BaseType* GetFunctionPrototype(const Function& function) const;
 
  private:
-  using TypeIdMap = std::map<uint64_t, BaseType*>;
-  using PrototypesMap = std::map<Address, const BaseType*>;
+  using TypeIdMap = absl::flat_hash_map<uint64_t, BaseType*>;
+  using PrototypesMap = absl::flat_hash_map<Address, const BaseType*>;
 
   template<class T> void CollectCompoundTypes(T start_it, T end_it);
   template<class T> void CollectMemberTypes(T start_it, T end_it);

--- a/instruction.cc
+++ b/instruction.cc
@@ -36,7 +36,7 @@ struct TreeNode {
   Children children;  // Should be stored sorted by position.
 };
 
-typedef std::vector<std::shared_ptr<TreeNode>> Tree;
+using Tree = std::vector<std::shared_ptr<TreeNode>>;
 
 // TODO(cblichmann): Immediate floats are rendered as hex and aren't properly
 //                   checked for their sign.

--- a/nested_iterator.h
+++ b/nested_iterator.h
@@ -16,13 +16,13 @@
 // containers, iterating on elements of the inner containers. NestedIterator
 // is a forward iterator, reverse iteration and random access are not supported.
 //
-// Examples:
+// Example:
 //
-// typedef vector<vector<int> > Vec;
+// using Vec = vector<vector<int>>;
 // Vec v;
 // ...
-// NestedIterator<Vec> it(v.begin(), v.end())
-// NestedIterator<Vec> end(v.end())
+// NestedIterator<Vec> it(v.begin(), v.end());
+// NestedIterator<Vec> end(v.end());
 // while (it != end) {
 //   int i = *it;
 //   ...
@@ -38,20 +38,19 @@ template<typename OuterIterator> class NestedIterator {
  private:
   template<typename Pointer>
   struct Traits {
-    typedef typename OuterIterator::value_type::iterator iterator;
+    using iterator = typename OuterIterator::value_type::iterator;
   };
 
   template<typename Pointer> struct Traits<const Pointer*> {
-    typedef typename OuterIterator::value_type::const_iterator iterator;
+    using iterator = typename OuterIterator::value_type::const_iterator;
   };
 
  public:
-  typedef NestedIterator<OuterIterator> iterator_type;
+  using iterator_type = NestedIterator<OuterIterator>;
 
-  typedef typename Traits<typename OuterIterator::pointer>::iterator
-      InnerIterator;
-  typedef typename InnerIterator::reference reference;
-  typedef typename InnerIterator::pointer pointer;
+  using InnerIterator = typename Traits<typename OuterIterator::pointer>::iterator;
+  using reference = typename InnerIterator::reference ;
+  using pointer = typename InnerIterator::pointer;
 
   NestedIterator(const OuterIterator& oi, const OuterIterator& oend,
       const InnerIterator& ii)

--- a/operand.h
+++ b/operand.h
@@ -39,6 +39,7 @@ class Operand {
   static Operand* CreateOperand(const Expressions& expressions);
   static void EmptyCache();
   static const OperandCache& GetOperands();
+  // TODO(cblichmann): Unused?
   static void PurgeCache(const std::set<int>& ids_to_keep);
   const Expression& GetExpression(int index) const;
   const Expression& GetLastExpression() const;

--- a/range.h
+++ b/range.h
@@ -29,13 +29,13 @@
 template <typename Container, typename Iterator = typename Container::iterator>
 class Range {
  public:
-  typedef Iterator iterator;
-  typedef typename Container::const_iterator const_iterator;
-  typedef typename Container::reference reference;
-  typedef typename Container::const_reference const_reference;
-  typedef typename Container::pointer pointer;
-  typedef typename Container::const_pointer const_pointer;
-  typedef typename Container::size_type size_type;
+  using iterator = Iterator;
+  using const_iterator = typename Container::const_iterator;
+  using reference = typename Container::reference ;
+  using const_reference = typename Container::const_reference;
+  using pointer = typename Container::pointer;
+  using const_pointer = typename Container::const_pointer;
+  using size_type = typename Container::size_type;
 
   explicit Range(const Container& c) : Range(c.begin(), c.end()) {}
 
@@ -47,11 +47,9 @@ class Range {
   Range(iterator begin, iterator end) : begin_(begin), end_(end) {}
 
   iterator begin() { return begin_; }
-
   const_iterator begin() const { return begin_; }
 
   iterator end() { return end_; }
-
   const_iterator end() const { return end_; }
 
   size_type size() const { return end_ - begin_; }

--- a/reader/graph_utility_test.cc
+++ b/reader/graph_utility_test.cc
@@ -29,7 +29,7 @@ class GraphUtilityTest : public testing::Test {
   const std::vector<Address> addresses_{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
                                         10, 11, 12, 13, 14, 15, 16, 16, 18, 19};
 
-  typedef std::pair<uint32_t, uint32_t> edge;
+  using edge = std::pair<uint32_t, uint32_t>;
   const std::vector<edge> edges_{
       {0, 1},   {1, 2},   {2, 3},   {3, 4},   {4, 5},   {5, 6},   {5, 7},
       {5, 8},   {5, 9},   {6, 10},  {7, 10},  {8, 10},  {9, 10},  {10, 11},
@@ -53,31 +53,32 @@ class GraphUtilityTest : public testing::Test {
  public:
   struct EdgeProperty {};
 
-  typedef boost::compressed_sparse_row_graph<boost::bidirectionalS, VertexInfo,
-                                             EdgeProperty, boost::no_property,
-                                             uint32_t, uint32_t>
-      Graph;
+  using Graph =
+      boost::compressed_sparse_row_graph<boost::bidirectionalS, VertexInfo,
+                                         EdgeProperty, boost::no_property,
+                                         uint32_t, uint32_t>;
 
   Graph graph_;
 
-  typedef boost::graph_traits<Graph>::vertex_descriptor Vertex;
-  typedef boost::graph_traits<Graph>::edge_descriptor Edge;
-  typedef boost::graph_traits<Graph>::edge_iterator EdgeIterator;
-  typedef boost::graph_traits<Graph>::out_edge_iterator OutEdgeIterator;
-  typedef boost::graph_traits<Graph>::in_edge_iterator InEdgeIterator;
-  typedef boost::graph_traits<Graph>::adjacency_iterator AdjacencyIterator;
+  using Vertex = boost::graph_traits<Graph>::vertex_descriptor;
+  using Edge = boost::graph_traits<Graph>::edge_descriptor;
+  using EdgeIterator = boost::graph_traits<Graph>::edge_iterator;
+  using OutEdgeIterator = boost::graph_traits<Graph>::out_edge_iterator;
+  using InEdgeIterator = boost::graph_traits<Graph>::in_edge_iterator;
+  using AdjacencyIterator = boost::graph_traits<Graph>::adjacency_iterator;
 
-  typedef boost::property_map<Graph, boost::vertex_index_t>::type
-      VertexIndexMap;
+  using VertexIndexMap =
+      boost::property_map<Graph, boost::vertex_index_t>::type;
 
-  typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
-                                VertexInfo, EdgeProperty> UndirectedGraph;
+  using UndirectedGraph =
+      boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
+                            VertexInfo, EdgeProperty>;
 
  protected:
   void SetUp() override {
     graph_ = Graph(boost::edges_are_unsorted_multi_pass, edges_.begin(),
                    edges_.end(), addresses_.size());
-    typedef boost::graph_traits<Graph>::vertex_iterator VertexIterator;
+    using VertexIterator = boost::graph_traits<Graph>::vertex_iterator;
     VertexIterator vertices_it, vertices_end;
     int j = 0;
     for (boost::tie(vertices_it, vertices_end) = boost::vertices(graph_);

--- a/reader/instruction.h
+++ b/reader/instruction.h
@@ -53,7 +53,7 @@ class Instruction {
   CallTargets call_targets_;
 };
 
-typedef std::vector<Instruction> Instructions;
+using Instructions = std::vector<Instruction>;
 
 const Instruction* GetInstruction(const Instructions& instructions,
                                   const Address instruction_address);

--- a/type_system.h
+++ b/type_system.h
@@ -99,7 +99,7 @@ class TypeSystem {
     int base_type_id;
     BaseType::MemberIds member_path;
   };
-  typedef std::vector<TypeSubstitution> TypeSubstitutions;
+  using TypeSubstitutions = std::vector<TypeSubstitution>;
 
   // Represents a data cross reference (to a type instance).
   struct DataXRef {
@@ -115,7 +115,7 @@ class TypeSystem {
     int expression_id;
     const TypeInstance* type_instance;
   };
-  typedef std::set<DataXRef> DataXRefs;
+  using DataXRefs = std::set<DataXRef>;
 
   const TypeSubstitutions& GetTypeSubstitutions() const {
     return type_substitutions_;

--- a/util/timer_test.cc
+++ b/util/timer_test.cc
@@ -23,10 +23,10 @@ namespace {
 // increases in units of 5 seconds (until the underlying time_point
 // representation wraps around).
 struct MockSteadyClock {
-  typedef std::chrono::seconds duration;
-  typedef duration::rep rep;
-  typedef duration::period period;
-  typedef std::chrono::time_point<MockSteadyClock, duration> time_point;
+  using duration = std::chrono::seconds;
+  using rep = duration::rep;
+  using period = duration::period;
+  using time_point = std::chrono::time_point<MockSteadyClock, duration>;
 
   static constexpr bool is_steady = true;
 

--- a/virtual_memory.h
+++ b/virtual_memory.h
@@ -19,6 +19,8 @@
 #include <map>
 #include <vector>
 
+#include "absl/container/btree_map.h"
+#include "absl/container/flat_hash_map.h"
 #include "third_party/zynamics/binexport/types.h"
 
 class AddressSpace {
@@ -30,9 +32,9 @@ class AddressSpace {
   };
 
   using MemoryBlock = std::vector<Byte>;
-  using Data = std::map<Address, MemoryBlock>;
-  using Flags = std::map<Address, int>;
-  using Ids = std::map<Address, int>;
+  using Data = absl::btree_map<Address, MemoryBlock>;
+  using Flags = absl::flat_hash_map<Address, int>;
+  //using Ids = absl::btree_map<Address, int>;
 
   // Copies the block. Returns true iff the block was added successfully, false
   // if the block overlaps with existing memory.

--- a/virtual_memory.h
+++ b/virtual_memory.h
@@ -29,10 +29,10 @@ class AddressSpace {
     kExecute = 1 << 2  // Address space is executable.
   };
 
-  typedef std::vector<Byte> MemoryBlock;
-  typedef std::map<Address, MemoryBlock> Data;
-  typedef std::map<Address, int> Flags;
-  typedef std::map<Address, int> Ids;
+  using MemoryBlock = std::vector<Byte>;
+  using Data = std::map<Address, MemoryBlock>;
+  using Flags = std::map<Address, int>;
+  using Ids = std::map<Address, int>;
 
   // Copies the block. Returns true iff the block was added successfully, false
   // if the block overlaps with existing memory.


### PR DESCRIPTION
Replace standard containers with Abseil ones, improving performance a lot, at least according to my totally unscientific tests :)
This PR also includes a bit of C++ modernization cleanup.