### PR TITLE
Fix the binary ninja plugin build after the introduction of fmt library into the binary ninja API

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -25,14 +25,11 @@ jobs:
     - name: Create Build Environment
       env:
         RUNNER_WORKSPACE: ${{ runner.workspace }}
-        IDASDK_SECRET: ${{ secrets.IDASDK_SECRET }}
       working-directory: ${{ github.workspace }}
       shell: bash
       run: |
         cmake -E make_directory "${RUNNER_WORKSPACE}/build"
         ./.github/scripts/decrypt_secret.sh
-        unzip -q "${RUNNER_WORKSPACE}/build/idasdk_teams80.zip" \
-          -d "${RUNNER_WORKSPACE}/build/"
 
     - name: Enable Developer Command Prompt (Windows)
       if: matrix.os == 'windows-2022'
@@ -48,7 +45,8 @@ jobs:
       run: |
         cmake "${GITHUB_WORKSPACE}" -G Ninja \
           "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}" \
-          "-DIdaSdk_ROOT_DIR=${{ runner.workspace }}/build/idasdk_teams80"
+          "-DBINEXPORT_BINARYNINJA_CHANNEL=DEV" \
+          "-DBINEXPORT_ENABLE_IDAPRO=OFF"
 
     - name: Build
       working-directory: ${{ runner.workspace }}/build
@@ -66,5 +64,4 @@ jobs:
         name: BinExport-${{ runner.os }}
         path: |
           ${{ runner.workspace }}/build/binaryninja/binexport*
-          ${{ runner.workspace }}/build/ida/binexport*
           ${{ runner.workspace }}/build/tools/binexport2dump*

--- a/binaryninja/stubs/binaryninjacore.cc
+++ b/binaryninja/stubs/binaryninjacore.cc
@@ -21,7 +21,7 @@
 // clang-format off
 #include "exceptions.h"  // NOLINT
 #define BINARYNINJACORE_LIBRARY
-#include "binaryninjaapi.h"  // NOLINT
+#include "binaryninjacore.h"  // NOLINT
 // clang-format on
 
 extern "C" {

--- a/binaryninja/stubs/binaryninjacore_stable.cc
+++ b/binaryninja/stubs/binaryninjacore_stable.cc
@@ -21,7 +21,7 @@
 // clang-format off
 #include "exceptions.h"  // NOLINT
 #define BINARYNINJACORE_LIBRARY
-#include "binaryninjaapi.h"  // NOLINT
+#include "binaryninjacore.h"  // NOLINT
 // clang-format on
 
 extern "C" {

--- a/binaryninja/stubs/regenerate-api-stubs.sh
+++ b/binaryninja/stubs/regenerate-api-stubs.sh
@@ -70,7 +70,7 @@ cd "${THIS_DIR}"
 // clang-format off
 #include "exceptions.h"  // NOLINT
 #define BINARYNINJACORE_LIBRARY
-#include "binaryninjaapi.h"  // NOLINT
+#include "binaryninjacore.h"  // NOLINT
 // clang-format on
 
 extern "C" {

--- a/cmake/BinExportDeps.cmake
+++ b/cmake/BinExportDeps.cmake
@@ -98,7 +98,6 @@ if(BINEXPORT_ENABLE_BINARYNINJA)
   FetchContent_Declare(binaryninjaapi
     GIT_REPOSITORY https://github.com/Vector35/binaryninja-api.git
     GIT_TAG        ${_binexport_binaryninja_git_tag}
-    GIT_SUBMODULES "docs" # Workaround for CMake #20579
   )
   FetchContent_GetProperties(binaryninjaapi)
   if(NOT binaryninjaapi_POPULATED)


### PR DESCRIPTION
A while ago, we (vector35) added fmt as a dependency in the binaryninja-api and that is breaking the binexport build. I made two fixes to it so the build can work. The two fixes are:

1. when cloning the binaryninja-api repo, recursively clone all submodules. This will include the fmt library which is necessary for it to build. The reason that I did not specify this fmt library explicity in the CMake is that will break the build for people trying to build against an earlier version of BN, e.g., the stable 3.5, which is before we introduced the fmt into the binaryninja-api. The tradeoff is several unnecessary submodules will also be cloned, but I think that is a reasonable tradeoff. 
2. I include `binaryninjacore.h` instead of the `binaryninjaapi.h` in the `binaryninjacore.cc`. `binaryninjaapi.h` references fmt as well as many other irrelevant things for the purpose of building a substitute binaryninjacore, so I included the `binaryninjacore.h` which has less distractions. 

I am testing against the Jordan's binexport build script: https://gist.github.com/psifertex/31d9bc3167eca91e466ebaae4382521c, though I believe it should also fix the build for other script or workflow.