### PR TITLE
CI: Ghidra: multiple build versions by default, monthly actions trigger, ability to specify Ghidra versions manually

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,8 +35,8 @@ jobs:
       run: |
         gradle buildExtension -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}
 
-    - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v3.1.2
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
       with:
         name: BinExport_Ghidra-Java
         path: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -43,6 +43,6 @@ jobs:
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: BinExport_Ghidra-Java
+        name: BinExport_Ghidra_${{ matrix.ghidra }}
         path: |
           ${{ github.workspace }}/java/dist/*

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,6 +4,11 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      ghidra_version:
+        description: 'Specify the Ghidra version(s) you want to build for (e.g. "latest", "11.0")'
+        required: true
+        default: '"latest"'
   schedule:
     - cron: '0 0 1 * *' # Monthly
 
@@ -12,15 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghidra:
-        - "latest"
-        - "11.1.2"
-        - "11.1.1"
-        - "11.1"
-        - "11.0.3"
-        - "11.0.2"
-        - "11.0.1"
-        - "11.0"
+        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest","11.1.2","11.1.1","11.1","11.0.3","11.0.2","11.0.1","11.0"')) }}
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,6 @@
 name: gradle-build
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,11 @@
 name: gradle-build
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *' # Monthly
 
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,8 +12,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-        - ghidra: 11.0.3
+        ghidra:
+        - "latest"
+        - "11.1.2"
+        - "11.1.1"
+        - "11.1"
+        - "11.0.3"
+        - "11.0.2"
+        - "11.0.1"
+        - "11.0"
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
# gradle-build

- Updated `upload-artifact` action to version 4
- Monthly build is added to verify the CI functionality and compatibility of the current code with the latest version of Ghidra
- The following versions are now compiled by default: latest, versions from 11.1.2 to 11.0
- However, on the Actions page, you can manually run the build with the version(s) of Ghidra you need: 
![ci](https://github.com/user-attachments/assets/a45fa1bb-8fde-48de-a5ff-ccafed7b2b31)
