### PR TITLE
Ghidra: java updated to version 21

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: "17"
+        java-version: "21"
 
     - name: Setup Ghidra
       uses: antoniovazquezblanco/setup-ghidra@v2.0.3

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'idea'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 


### PR DESCRIPTION
The new version of Ghidra numbered 11.2 was released today, and now binexport is built only with the JDK version 21 or newer (which is also noted in the description of Ghidra repo itself about the using JDK 21 or newer).

I tested new builds on JDK 21 in Ghidra versions 11.0 and 11.2 - the plugin works correctly as before, so I didn't notice any regression.