### PR TITLE
Ghidra: Implement BinExport.java Ghidra script

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,6 @@ directory.
 
 ### Ghidra
 
-There is only minimal integration into the Ghidra UI at this time.
-
 1.  Open or create a project. For new projects, import a file first using `File`|`Import File...`
 2.  Right-click a file in the current project list and select `Export...` from the context menu.
 3.  In the "Export" dialog, under "Format", choose "Binary Export (v2) for BinDiff".
@@ -199,6 +197,34 @@ There is only minimal integration into the Ghidra UI at this time.
     `.BinExport` will be appended automatically.
 5.  Optional: click "Options..." to set additional export options.
 6.  Click "OK", then click "OK" again to dismiss the "Export Results Summary" dialog.
+
+#### Scripting
+
+The `BinExport.java` Ghidra script can be run in both headless and GUI modes. In GUI mode, it is available under the `BinExport` category in the Script Manager. For headless mode, a `BinExport.properties` file with the following content (or similar, depending on the options you want to use) can be used:
+
+```
+Choose export file Export = test.BinExport
+Choose options IDA Pro Compatibility = "Subtract Imagebase;Remap mnemonics;Prepend Namespace to Function Names"
+```
+
+##### Example usage in headless mode
+
+Create a project, import and analyze a binary:
+
+```
+$ ./analyzeHeadless <project_location> <project_name> -import <file>
+```
+Run `BinExport.java` which will generate the `.BinExport` file specified in `BinExport.properties`:
+
+```
+$ ./analyzeHeadless <project_location> <project_name> -process <file> -propertiesPath <path> -preScript BinExport.java -noanalysis
+```
+
+Alternatively, use command-line arguments instead of `BinExport.properties`:
+
+```
+$ ./analyzeHeadless <project_location> <project_name> -process <file> -preScript BinExport.java test.BinExport "Prepend Namespace to Function Names" -noanalysis
+```
 
 ## How to build
 

--- a/java/ghidra_scripts/BinExport.java
+++ b/java/ghidra_scripts/BinExport.java
@@ -1,0 +1,117 @@
+// Copyright 2019-2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// @category BinExport
+
+import com.google.security.binexport.BinExport2Builder;
+import com.google.security.binexport.IdaProMnemonicMapper;
+import com.google.security.zynamics.BinExport.BinExport2;
+import ghidra.app.script.GhidraScript;
+import ghidra.app.util.exporter.ExporterException;
+import ghidra.framework.model.DomainObject;
+import ghidra.program.model.address.AddressSetView;
+import ghidra.program.model.listing.Program;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Exports Ghidra disassembly data into BinExport v2 format.
+ *
+ * @author Andras Gemes
+ * @author Christian Blichmann
+ */
+public class BinExport extends GhidraScript {
+
+  /** Stringized version number allowing for scriptable update. */
+  private static final String BINEXPORT_VERSION = "12";
+
+  /** Copyright that appears in the console. */
+  private static final String BINEXPORT_COPYRIGHT =
+      "BinExport " + BINEXPORT_VERSION + " (c)2019-2024 Google LLC";
+
+  /** Display name that appears in the console. */
+  private static final String BINEXPORT_DISPLAY_NAME = "Binary BinExport (v2) for BinDiff";
+
+  // Choice names
+  /** Whether to subtract the program image base from addresses for export. */
+  private static final String IDAPRO_COMPAT_OPT_SUBTRACT_IMAGEBASE = "Subtract Imagebase";
+
+  /** Whether to remap Ghidra's mnemonics into IDA Pro style ones. */
+  private static final String IDAPRO_COMPAT_OPT_REMAP_MNEMONICS = "Remap mnemonics";
+
+  /** Whether to prepend "namespace::" to function names where the namespace is not "Global" */
+  private static final String IDAPRO_COMPAT_OPT_PREPEND_NAMESPACE =
+      "Prepend Namespace to Function Names";
+
+  @Override
+  protected void run() throws Exception {
+    println(BINEXPORT_DISPLAY_NAME);
+    println(BINEXPORT_COPYRIGHT);
+    File outputFile = askFile("Choose export file", "Export");
+
+    List<String> choices =
+        askChoices(
+            "Choose options",
+            "IDA Pro Compatibility",
+            Arrays.asList(
+                IDAPRO_COMPAT_OPT_SUBTRACT_IMAGEBASE,
+                IDAPRO_COMPAT_OPT_REMAP_MNEMONICS,
+                IDAPRO_COMPAT_OPT_PREPEND_NAMESPACE));
+
+    DomainObject domainObj = currentProgram;
+    AddressSetView addrSet = currentProgram.getMemory();
+
+    if (!export(outputFile, domainObj, addrSet, choices)) {
+      printerr("Export failed");
+    } else {
+      println("Export successful");
+    }
+  }
+
+  public boolean export(
+      File file, DomainObject domainObj, AddressSetView addrSet, List<String> selectedOptions)
+      throws ExporterException, IOException {
+
+    if (!(domainObj instanceof Program)) {
+      printerr("Unsupported type: " + domainObj.getClass().getName());
+      return false;
+    }
+
+    Program program = (Program) domainObj;
+
+    var builder = new BinExport2Builder(program, addrSet);
+
+    if (selectedOptions.contains(IDAPRO_COMPAT_OPT_REMAP_MNEMONICS)) {
+      builder.setMnemonicMapper(new IdaProMnemonicMapper(program.getLanguage()));
+    }
+    if (selectedOptions.contains(IDAPRO_COMPAT_OPT_SUBTRACT_IMAGEBASE)) {
+      builder.setAddressOffset(program.getImageBase().getOffset());
+    }
+    if (selectedOptions.contains(IDAPRO_COMPAT_OPT_PREPEND_NAMESPACE)) {
+      builder.setPrependNamespace(true);
+    }
+
+    final BinExport2 proto = builder.build();
+
+    println("Writing BinExport2 file");
+    try (var outputStream = new FileOutputStream(file)) {
+      proto.writeTo(outputStream);
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
## Overview

I have implemented a Ghidra script to enable scripting as previously `.BinExport` files could be created only in the UI. The code is mainly a rewrite of `BinExportExporter.java` with some modifications necessary for Ghidra scripts. I formatted the code using [google-java-format](https://github.com/google/google-java-format):

```
$ java -jar ~/Downloads/google-java-format-1.24.0-all-deps.jar --replace BinExport.java
```

## Testing

I thoroughly tested the code in both headless mode (its main purpose) and the GUI.

### Headless mode

Create a project, import and analyze a binary:

```
$ ./support/analyzeHeadless /home/gemesa/git-repos/my-projects fidb-rust -import /home/gemesa/git-repos/tmp/rust-lib/rustlib-small/rustc-1.81.0/testlib/1.0.0/x64-debug-build/45c91108d938afe8-absvdi2.o -overwrite
```

Run `BinExport.java` which generates the `.BinExport` file specified in `BinExport.properties`:

```
$ cat BinExport.properties
Choose export file Export = test.BinExport
Choose options (IDA Pro Compatibility) OK = "Subtract Imagebase;Remap mnemonics;Prepend Namespace to Function Names"
$ ./support/analyzeHeadless /home/gemesa/git-repos/my-projects fidb-rust -process 45c91108d938afe8-absvdi2.o -propertiesPath /home/gemesa/git-repos/binexport/java/ghidra_scripts -preScript BinExport.java -noanalysis
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Temurin-21.0.4+7 (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.4+7 (build 21.0.4+7-LTS, mixed mode)
...
INFO  HEADLESS Script Paths:
...
    /home/gemesa/.config/ghidra/ghidra_11.3_DEV/Extensions/BinExport/ghidra_scripts
...
INFO  HEADLESS: execution starts (HeadlessAnalyzer)  
INFO  Opening existing project: /home/gemesa/git-repos/my-projects/fidb-rust (HeadlessAnalyzer)  
INFO  Opening project: /home/gemesa/git-repos/my-projects/fidb-rust (HeadlessProject)  
INFO  REPORT: Processing project file: /45c91108d938afe8-absvdi2.o (HeadlessAnalyzer)  
INFO  Packed database cache: /var/tmp/gemesa-ghidra/packed-db-cache (PackedDatabaseCache)  
INFO  SCRIPT: /home/gemesa/.config/ghidra/ghidra_11.3_DEV/Extensions/BinExport/ghidra_scripts/BinExport.java (HeadlessAnalyzer)  
INFO  Reading script properties file: /home/gemesa/git-repos/binexport/java/ghidra_scripts/BinExport.properties (GhidraScriptProperties)  
INFO  BinExport.java> Binary BinExport (v2) for BinDiff (GhidraScript)  
INFO  BinExport.java> BinExport 12 (c)2019-2024 Google LLC (GhidraScript)  
INFO  BinExport.java> Writing BinExport2 file (GhidraScript)  
INFO  BinExport.java> Export successful (GhidraScript)  
INFO  REPORT: Save succeeded for processed file: /45c91108d938afe8-absvdi2.o (HeadlessAnalyzer)
$ file test.BinExport 
test.BinExport: data
```

### GUI

After installing the plugin the script is available in the Script Manager:

![image](https://github.com/user-attachments/assets/b511d7b9-72ca-433e-b0bc-51f7f5583672)

When running it, it first asks for the export file name:

![image](https://github.com/user-attachments/assets/0adc1a59-65e6-4749-8aaa-0bb13c435e7a)

Then the options can be specified:

![image](https://github.com/user-attachments/assets/f4b937a6-e68f-4d29-b0bb-518e47a71fde)

The console output is the same as when running it in headless mode:

![image](https://github.com/user-attachments/assets/62ac1881-d5d0-4635-b392-43322cda10ab)

### Options

Testing if prepending namespaces works:

![image](https://github.com/user-attachments/assets/f4127c39-3c78-46aa-a6b4-4a95789431ee)

```
$ binexport2dump std-16341e9decf4fc92.std.58aa595429f4953e-cgu.00.rcgu.o.BinExport | head -n 10 
Original executable name: std-16341e9decf4fc92.std.58aa595429f4953e-cgu.00.rcgu.o
Executable Id:            19c5d70c74fa7c5939acd7f288c0bc4f69121758a0d5d58b659fa0f8ffce3816
Architecture:             x86-64
Creation time (local):    2024-10-16T19:01:16+02:00

Functions:
00100000 n core::ptr::drop_in_place<(std::ffi::os_str::OsString,core::option::Option<std::ffi::os_str::OsString>)>
00100050 n core::ptr::drop_in_place<std::ffi::os_str::OsString>
00100070 n core::ptr::drop_in_place<core::option::Option<std::ffi::os_str::OsString>>
001000A0 n core::ptr::drop_in_place<(std::ffi::os_str::OsString,std::ffi::os_str::OsString)>
```

Testing if not prepending namespaces works:

![image](https://github.com/user-attachments/assets/93184918-ef75-411e-b2df-689409824cf0)

```
$ binexport2dump std-16341e9decf4fc92.std.58aa595429f4953e-cgu.00.rcgu.o.BinExport.no-namespace | head -n 10
Original executable name: std-16341e9decf4fc92.std.58aa595429f4953e-cgu.00.rcgu.o
Executable Id:            19c5d70c74fa7c5939acd7f288c0bc4f69121758a0d5d58b659fa0f8ffce3816
Architecture:             x86-64
Creation time (local):    2024-10-16T19:00:52+02:00

Functions:
00100000 n drop_in_place<(std::ffi::os_str::OsString,core::option::Option<std::ffi::os_str::OsString>)>
00100050 n drop_in_place<std::ffi::os_str::OsString>
00100070 n drop_in_place<core::option::Option<std::ffi::os_str::OsString>>
001000A0 n drop_in_place<(std::ffi::os_str::OsString,std::ffi::os_str::OsString)>
```

## References

- https://static.grumpycoder.net/pixel/support/analyzeHeadlessREADME.html
- https://ghidra.re/ghidra_docs/api/ghidra/app/script/GhidraScript.html
- https://ghidra.re/ghidra_docs/api/ghidra/app/script/GhidraScript.html#askFile(java.lang.String,java.lang.String)
- https://ghidra.re/ghidra_docs/api/ghidra/app/script/GhidraScript.html#askChoices(java.lang.String,java.lang.String,java.util.List)