### PR TITLE
fix(build): name library `ida64` instead of `ida` on macOS

### DIFF
--- a/cmake/FindIdaSdk.cmake
+++ b/cmake/FindIdaSdk.cmake
@@ -213,9 +213,9 @@ if(APPLE)
                     -output "${_ida64_universal_lib}"
       )
     endif()
-    add_library(ida SHARED IMPORTED)
-    add_dependencies(ida ida64_universal)
-    set_target_properties(ida PROPERTIES
+    add_library(ida64 SHARED IMPORTED)
+    add_dependencies(ida64 ida64_universal)
+    set_target_properties(ida64 PROPERTIES
       IMPORTED_LOCATION "${_ida64_universal_lib}"
     )
 


### PR DESCRIPTION
Although in IDA SDK 9.0 and later there is `libida.dylib`, in order to build BinDiff, we need to name our library `ida64` instead of `ida`, or the linker complains `library not found for -lida64`.

```plaintext
[622/625] Linking CXX shared module ida/bindiff8_ida64.dylib
FAILED: ida/bindiff8_ida64.dylib 

ld: library not found for -lida64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Here is the full build log: https://github.com/Lil-Ran/build-bindiff-for-ida-9/actions/runs/15194920546

On Windows and Linux the name `ida64` is kept in `FindIdaSdk.cmake`, and it worked. After the modification of macOS part in this PR, I built it successfully: https://github.com/Lil-Ran/build-bindiff-for-ida-9/actions/runs/15196307456