### PR TITLE
Bump GitHub Actions versions to fix artifact upload

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         include:
         - os: ubuntu-22.04
-        - os: macos-12
+        - os: macos-13
         - os: windows-2022
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,10 +28,10 @@ jobs:
       working-directory: ${{ github.workspace }}
       shell: bash
       run: |
-        mkdir -p "${{ runner.workspace }}/build"
+        mkdir -p "${{ github.workspace }}/build"
         ./.github/scripts/decrypt_secret.sh
-        unzip -q "${{ runner.workspace }}/build/idasdk_teams82.zip" \
-              -d "${{ runner.workspace }}/build/"
+        unzip -q "${{ github.workspace }}/build/idasdk_teams82.zip" \
+              -d "${{ github.workspace }}/build/"
 
     - name: Enable Developer Command Prompt (Windows)
       if: matrix.os == 'windows-2022'
@@ -42,20 +42,20 @@ jobs:
       uses: rui314/setup-mold@v1
 
     - name: Configure CMake
-      working-directory: ${{ runner.workspace }}/build
+      working-directory: ${{ github.workspace }}/build
       shell: bash
       run: |
         cmake "${{ github.workspace }}" -G Ninja \
           "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}" \
-          "-DIdaSdk_ROOT_DIR=${{ runner.workspace }}/build/idasdk_teams82"
+          "-DIdaSdk_ROOT_DIR=${{ github.workspace }}/build/idasdk_teams82"
 
     - name: Build
-      working-directory: ${{ runner.workspace }}/build
+      working-directory: ${{ github.workspace }}/build
       shell: bash
       run: cmake --build . --config "${BUILD_TYPE}"
 
     - name: Test
-      working-directory: ${{ runner.workspace }}/build
+      working-directory: ${{ github.workspace }}/build
       shell: bash
       run: ctest --build-config "${BUILD_TYPE}" --output-on-failure -R '^[A-Z]'
 
@@ -64,6 +64,6 @@ jobs:
       with:
         name: BinExport-${{ runner.os }}
         path: |
-          ${{ runner.workspace }}/build/binaryninja/binexport*
-          ${{ runner.workspace }}/build/ida/binexport*
-          ${{ runner.workspace }}/build/tools/binexport2dump*
+          ${{ github.workspace }}/build/binaryninja/binexport*
+          ${{ github.workspace }}/build/ida/binexport*
+          ${{ github.workspace }}/build/tools/binexport2dump*

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Enable Developer Command Prompt (Windows)
       if: matrix.os == 'windows-2022'
-      uses: ilammy/msvc-dev-cmd@v1.12.1
+      uses: ilammy/msvc-dev-cmd@v1.13.0
 
     - name: Enable mold linker (Linux)
       if: matrix.os == 'ubuntu-22.04'
@@ -60,7 +60,7 @@ jobs:
       run: ctest --build-config "${BUILD_TYPE}" --output-on-failure -R '^[A-Z]'
 
     - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v4
       with:
         name: BinExport-${{ runner.os }}
         path: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest","11.1.2","11.1.1","11.1","11.0.3","11.0.2","11.0.1","11.0"')) }}
+        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest","11.3.2","11.3.1","11.3","11.2.1","11.2","11.1.2","11.1.1","11.1","11.0.3","11.0.2","11.0.1","11.0"')) }}
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,12 +30,12 @@ jobs:
         java-version: "21"
 
     - name: Setup Ghidra
-      uses: antoniovazquezblanco/setup-ghidra@v2.0.3
+      uses: antoniovazquezblanco/setup-ghidra@v2.0.12
       with:
         version: ${{ matrix.ghidra }}
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v4
       with:
         gradle-version: 8.7
 


### PR DESCRIPTION
The cmake workflow building the C++ project fails to upload artifacts for a while due to the upload-artifact Action changing the backend in v4 to be incompatible with v3 forcing everyone to update.

The macos-12 runner image was removed on 12/3/24 so update to the next oldest available one. I'm not sure the build dependencies are meant to be old to allow running on older versions?

Build Ghidra plugins for all newer Ghidra versions too for easy installation of whatever version you're running.

I couldn't test the workflow in my fork due to the encrypted idasdk requirement.