### PR TITLE
Update to Ghidra 11.4.1

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest","11.1.2","11.1.1","11.1","11.0.3","11.0.2","11.0.1","11.0"')) }}
+        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest","11.4.1","11.4","11.3.2","11.3.1","11.3","11.2.1","11.2","11.1.2","11.1.1","11.1","11.0.3","11.0.2","11.0.1","11.0"')) }}
     runs-on: ubuntu-22.04
 
     steps:

--- a/java/src/main/java/com/google/security/binexport/BinExport2Builder.java
+++ b/java/src/main/java/com/google/security/binexport/BinExport2Builder.java
@@ -29,7 +29,9 @@ import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.block.BasicBlockModel;
 import ghidra.program.model.block.CodeBlock;
 import ghidra.program.model.block.CodeBlockReference;
+import ghidra.program.model.data.DataType;
 import ghidra.program.model.data.StringDataInstance;
+import ghidra.program.model.data.StringDataType;
 import ghidra.program.model.lang.OperandType;
 import ghidra.program.model.lang.Register;
 import ghidra.program.model.listing.CodeUnit;
@@ -69,8 +71,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
-import util.CollectionUtils;
 
 /**
  * Java implementation of the BinExport2 writer class for Ghidra using a builder pattern.
@@ -944,7 +946,13 @@ public class BinExport2Builder {
     monitor.setIndeterminate(true);
     var strToInstr = new ArrayList<Map.Entry<Integer, Integer>>();
 
-    for (Data data : CollectionUtils.asIterable(DefinedDataIterator.definedStrings(program))) {
+    Listing listing = program.getListing();
+    AddressSetView memory = program.getMemory();
+
+    DefinedDataIterator stringData = DefinedDataIterator.byDataType(program, memory, dt -> dt instanceof StringDataType);
+
+    while (stringData.hasNext()) {
+      Data data = stringData.next();
       if (monitor.isCancelled()) {
         return;
       }


### PR DESCRIPTION
definedStrings is no longer supported. This change breaks this extension, as seen in the compile-time errors:

(...)
> Task :compileJava
> **/home/runner/work/binexport/binexport/java/src/main/java/com/google/security/binexport/BinExport2Builder.java:947: error: cannot find symbol
>     for (Data data : CollectionUtils.asIterable(DefinedDataIterator.definedStrings(program))) {
>                                                                    ^**
(...)

This decision is seemingly undocumented as it does not appear in the [deprecated list](https://class.malware.re/stuff/ghidra_docs/api/deprecated-list.html) , and is likely due to [previous performance problems](https://github.com/NationalSecurityAgency/ghidra/issues/8134).

To prove that it is completely missing, we can look into the definitions in Ghidra\Framework\SoftwareModeling\lib\SoftwareModeling.jar by using:

`javap -classpath .\SoftwareModeling.jar ghidra.program.util.DefinedDataIterator`

In Ghidra 11.4.1:
> Compiled from "DefinedDataIterator.java"
> public class ghidra.program.util.DefinedDataIterator implements ghidra.program.model.listing.DataIterator {
>   public static ghidra.program.util.DefinedDataIterator byDataType(ghidra.program.model.listing.Program, java.util.function.Predicate<ghidra.program.model.data.DataType>);
>   public static ghidra.program.util.DefinedDataIterator byDataType(ghidra.program.model.listing.Program, ghidra.program.model.address.AddressSetView, java.util.function.Predicate<ghidra.program.model.data.DataType>);
>   public static ghidra.program.util.DefinedDataIterator byDataInstance(ghidra.program.model.listing.Program, java.util.function.Predicate<ghidra.program.model.listing.Data>);
>   public boolean hasNext();
>   public ghidra.program.model.listing.Data next();
>   public java.lang.Object next();
>   }

For comparsion, the same file In Ghidra 11.0.3 ( which is officially the last supported version ) :

> Compiled from "DefinedDataIterator.java"
> public class ghidra.program.util.DefinedDataIterator implements ghidra.program.model.listing.DataIterator {
>   public static ghidra.program.util.DefinedDataIterator byDataType(ghidra.program.model.listing.Program, java.util.function.Predicate<ghidra.program.model.data.DataType>);
>   public static ghidra.program.util.DefinedDataIterator byDataType(ghidra.program.model.listing.Program, ghidra.program.model.address.AddressSetView, java.util.function.Predicate<ghidra.program.model.data.DataType>);
>   public static ghidra.program.util.DefinedDataIterator byDataInstance(ghidra.program.model.listing.Program, java.util.function.Predicate<ghidra.program.model.listing.Data>);
>   public static ghidra.program.util.DefinedDataIterator definedStrings(ghidra.program.model.listing.Program);
>   public static ghidra.program.util.DefinedDataIterator definedStrings(ghidra.program.model.listing.Program, ghidra.program.model.address.AddressSetView);
>   public static ghidra.program.util.DefinedDataIterator definedStrings(ghidra.program.model.listing.Data);
>   public boolean hasNext();
>   public ghidra.program.model.listing.Data next();
>   public java.lang.Object next();
> }

This can be fixed by reproducing the same behavior by utilizing [byDataType](https://ghidra.re/ghidra_docs/api/ghidra/program/util/DefinedDataIterator.html#byDataType(ghidra.program.model.listing.Program,ghidra.program.model.address.AddressSetView,java.util.function.Predicate)).