### PR TITLE
Detect ida.exe vs ida64.exe at runtime to support IDA 9.0+

### DIFF
--- a/util/idb_export.cc
+++ b/util/idb_export.cc
@@ -58,19 +58,24 @@ absl::Status ExportDatabase(const std::string& idb_path,
     return absl::NotFoundError(absl::StrCat("File not found: " + idb_path));
   }
 
-#if IDA_SDK_VERSION < 900
+  // Pick the right IDA executable at runtime. IDA 9.0+ removed the separate
+  // ida64 binary and unified everything into ida(.exe); older releases ship
+  // both. Detect which is present in `options.ida_dir` so the same binary
+  // works against either layout. The compile-time IDA_SDK_VERSION switch
+  // previously used here was unreliable: binexport_shared is built without
+  // -DIDA_SDK_VERSION=…, so the macro defaulted to 0 and `ida64` was always
+  // selected — breaking IDA 9.x exports from the bindiff CLI.
   const bool is_64bit = absl::EndsWithIgnoreCase(idb_path, kIdbExtension64);
-  #ifdef _WIN32
-    const std::string ida_exe = is_64bit ? "ida64.exe" : "ida.exe";
-  #else
-    const std::string ida_exe = is_64bit ? "ida64" : "ida";
-  #endif
+#ifdef _WIN32
+  std::string ida_exe = "ida.exe";
+  if (is_64bit && FileExists(JoinPath(options.ida_dir, "ida64.exe"))) {
+    ida_exe = "ida64.exe";
+  }
 #else
-  #ifdef _WIN32
-    const std::string ida_exe = "ida.exe";
-  #else
-    const std::string ida_exe = "ida";
-  #endif
+  std::string ida_exe = "ida";
+  if (is_64bit && FileExists(JoinPath(options.ida_dir, "ida64"))) {
+    ida_exe = "ida64";
+  }
 #endif
   std::vector<std::string> args;
   args.push_back(JoinPath(options.ida_dir, ida_exe));


### PR DESCRIPTION
IDA 9.0 removed the separate ida64 binary and unified everything into a single ida(.exe) executable. The compile-time `#if IDA_SDK_VERSION < 900` switch previously used here is unreliable in practice: binexport_shared is compiled without -DIDA_SDK_VERSION=..., so the macro defaults to 0 and the old ida64 branch is always taken. As a result, `bindiff --export` shells out to a non-existent ida64.exe against IDA 9.x installs and produces zero exports.

Replace the compile-time switch with a runtime check based on which executable exists in options.ida_dir. This works across all supported IDA versions:

  - IDA 9.0+ (only ida.exe present): use ida.exe.
  - IDA 7.x/8.x (both ida.exe and ida64.exe present): use ida64.exe for 64-bit IDBs (.i64), ida.exe otherwise.

No public-API change; behavior is identical on older IDA installs.